### PR TITLE
remove unlisting when list length is zero

### DIFF
--- a/pymia/data/indexexpression.py
+++ b/pymia/data/indexexpression.py
@@ -50,4 +50,4 @@ class IndexExpression:
                 indexing.append(index)
             else:
                 raise ValueError("only 'int', 'slice', and 'None' types possible in expression")
-        return indexing if len(indexing) > 1 else indexing[0]
+        return indexing


### PR DESCRIPTION
I know this function is used in the pad extractor but I do not know how much it relies on it.

@fabianbalsiger: what do you think?