### PR TITLE
refactor(dataset): speed up ParameterizableDataset initialization

### DIFF
--- a/pymia/data/extraction/dataset.py
+++ b/pymia/data/extraction/dataset.py
@@ -38,7 +38,7 @@ class ParameterizableDataset(data.Dataset):
         self.indexing_strategy = indexing_strategy
         with rd.get_reader(self.dataset_path) as reader:
             all_subjects = reader.get_subjects()
-            last_shape = None
+            last_shape = None  # remember shape to optimize initialization
             for i, subject in enumerate(reader.get_subject_entries()):
                 if subject_subset is None or all_subjects[i] in subject_subset:
                     current_shape = reader.get_shape(subject)

--- a/pymia/data/extraction/dataset.py
+++ b/pymia/data/extraction/dataset.py
@@ -33,14 +33,19 @@ class ParameterizableDataset(data.Dataset):
     def set_extractor(self, extractor: extr.Extractor):
         self.extractor = extractor
 
-    def set_indexing_strategy(self, indexing_strategy: idx.IndexingStrategy, subject_subset: list=None):
+    def set_indexing_strategy(self, indexing_strategy: idx.IndexingStrategy, subject_subset: list = None):
         self.indices.clear()
         self.indexing_strategy = indexing_strategy
         with rd.get_reader(self.dataset_path) as reader:
             all_subjects = reader.get_subjects()
+            last_shape = None
             for i, subject in enumerate(reader.get_subject_entries()):
                 if subject_subset is None or all_subjects[i] in subject_subset:
-                    subject_indices = self.indexing_strategy(reader.get_shape(subject))
+                    current_shape = reader.get_shape(subject)
+                    if not last_shape == current_shape:
+                        subject_indices = self.indexing_strategy(current_shape)
+                        last_shape = current_shape
+
                     subject_and_indices = zip(len(subject_indices) * [i], subject_indices)
                     self.indices.extend(subject_and_indices)
 


### PR DESCRIPTION
I think we can speed up the dataset initialization by reusing the calculated indices when the shapes are consistent. This is essentially helpful for large datasets and/or large indexing dimensions.