### PR TITLE
refactor(evaluation): remove SimpleITKImageMetric

### DIFF
--- a/docs/pymia.evaluation.metric.rst
+++ b/docs/pymia.evaluation.metric.rst
@@ -10,8 +10,8 @@ All metrics implement the :class:`pymia.evaluation.metric.base.Metric` interface
 (e.g., with the :class:`pymia.evaluation.evaluator.SegmentationEvaluator`).
 To implement your own metric and use it with the :class:`pymia.evaluation.evaluator.Evaluator`, you need to inherit from
 :class:`pymia.evaluation.metric.base.Metric`, :class:`pymia.evaluation.metric.base.ConfusionMatrixMetric`,
-:class:`pymia.evaluation.metric.base.DistanceMetric`, :class:`pymia.evaluation.metric.base.SimpleITKImageMetric` or
-:class:`pymia.evaluation.metric.base.NumpyArrayMetric` and implement :func:`pymia.evaluation.metric.base.Metric.calculate`.
+:class:`pymia.evaluation.metric.base.DistanceMetric`, :class:`pymia.evaluation.metric.base.NumpyArrayMetric`, or
+:class:`pymia.evaluation.metric.base.SpacingMetric` and implement :func:`pymia.evaluation.metric.base.Metric.calculate`.
 
 .. note::
    The segmentation metrics are selected based on the paper by Taha and Hanbury. We recommend to refer to the paper for

--- a/pymia/evaluation/metric/__init__.py
+++ b/pymia/evaluation/metric/__init__.py
@@ -1,5 +1,5 @@
-from .base import (ConfusionMatrix, Distances, Metric, ConfusionMatrixMetric, DistanceMetric, SimpleITKImageMetric,
-                   NumpyArrayMetric, Information, NotComputableMetricWarning)
+from .base import (ConfusionMatrix, Distances, Metric, ConfusionMatrixMetric, DistanceMetric,
+                   NumpyArrayMetric, SpacingMetric, Information, NotComputableMetricWarning)
 from .metric import (get_segmentation_metrics, get_regression_metrics, get_overlap_metrics,
                      get_distance_metrics, get_classical_metrics)
 from .categorical import (Accuracy, AdjustedRandIndex, AreaUnderCurve, AverageDistance, CohenKappaCoefficient,

--- a/pymia/evaluation/metric/base.py
+++ b/pymia/evaluation/metric/base.py
@@ -465,7 +465,7 @@ class Metric(abc.ABC):
         return '{self.metric}'.format(self=self)
 
 
-class ConfusionMatrixMetric(Metric):
+class ConfusionMatrixMetric(Metric, abc.ABC):
 
     def __init__(self, metric: str = 'ConfusionMatrixMetric'):
         """Represents a metric based on the confusion matrix.
@@ -477,7 +477,7 @@ class ConfusionMatrixMetric(Metric):
         self.confusion_matrix = None  # ConfusionMatrix
 
 
-class DistanceMetric(Metric):
+class DistanceMetric(Metric, abc.ABC):
 
     def __init__(self, metric: str = 'DistanceMetric'):
         """Represents a metric based on distances.
@@ -489,20 +489,7 @@ class DistanceMetric(Metric):
         self.distances = None  # Distances
 
 
-class SimpleITKImageMetric(Metric):
-
-    def __init__(self, metric: str = 'SimpleITKImageMetric'):
-        """Represents a metric based on SimpleITK images.
-
-        Args:
-            metric (str): The identification string of the metric.
-        """
-        super().__init__(metric)
-        self.reference = None  # SimpleITK.Image
-        self.prediction = None  # SimpleITK.Image
-
-
-class NumpyArrayMetric(Metric):
+class NumpyArrayMetric(Metric, abc.ABC):
 
     def __init__(self, metric: str = 'NumpyArrayMetric'):
         """Represents a metric based on numpy arrays.
@@ -513,6 +500,18 @@ class NumpyArrayMetric(Metric):
         super().__init__(metric)
         self.reference = None  # np.ndarray
         self.prediction = None  # np.ndarray
+
+
+class SpacingMetric(NumpyArrayMetric, abc.ABC):
+
+    def __init__(self, metric: str = 'SpacingMetric'):
+        """Represents a metric based on images with a physical spacing.
+
+        Args:
+            metric (str): The identification string of the metric.
+        """
+        super().__init__(metric)
+        self.spacing = None  # tuple
 
 
 class Information(Metric):


### PR DESCRIPTION
Replaces `SimpleITKImageMetric` by `SpacingMetric`. Therefore, we do not longer require a SimpleITK image as an argument in the `SegmentationEvaluator` when calculating a `SimpleITKImageMetric` metric.

@alainjungo please have a quick look