### PR TITLE
refactor(SelectiveDataExtractor): remove dependency on NamesExtractor…

### DIFF
--- a/pymia/data/definition.py
+++ b/pymia/data/definition.py
@@ -24,6 +24,7 @@ LOC_DATA_PLACEHOLDER = 'data/{}'
 KEY_SUBJECT_FILES = 'subject_files'  #:
 KEY_CATEGORIES = 'categories'  #:
 KEY_PLACEHOLDER_NAMES = '{}_names'  #:
+KEY_PLACEHOLDER_NAMES_SELECTED = '{}_names_selected'  #:
 KEY_PLACEHOLDER_PROPERTIES = '{}_properties'  #:
 KEY_PLACEHOLDER_FILES = '{}_files'  #:
 KEY_FILE_ROOT = 'file_root'  #:


### PR DESCRIPTION
… and provide selected names of entries to extraction, closes #24

The changes are illustrated by this minimal running example:

```
import numpy as np
import pymia.data.definition as defs
import pymia.data.extraction as extr

hdf_file = '../example-data/example-dataset.h5'


def get_sample(selection = None):
    indexing_strategy = extr.SliceIndexing()

    if selection is None:
        extractor = extr.ComposeExtractor(
            [extr.DataExtractor(categories=(defs.KEY_IMAGES, ))])
    else:
        extractor = extr.ComposeExtractor(
            [
                # extr.NamesExtractor(),  # before, this was required
                extr.SelectiveDataExtractor(selection=selection, category=defs.KEY_IMAGES)]
        )

    dataset = extr.PymiaDatasource(hdf_file, indexing_strategy, extractor)
    return dataset[0]


sample0 = get_sample(None)
sample1 = get_sample(('T1', 'T2'))
sample2 = get_sample(('T2', 'T1'))
print('Default extraction: ', np.array_equal(sample0[defs.KEY_IMAGES], sample1[defs.KEY_IMAGES]))  # True
print(' - Extracted images entry names: ', sample1['images_names_selected'])
print('Swapped extraction: ', np.array_equal(sample1[defs.KEY_IMAGES], sample2[defs.KEY_IMAGES]))  # False, as it should be because we swapped the entries T1 and T2 to T2 and T1
print(' - Extracted images entry names: ', sample2['images_names_selected'])
```