### PR TITLE
Solved minor issue in Jaccard computation

### DIFF
--- a/pymia/evaluation/metric/categorical.py
+++ b/pymia/evaluation/metric/categorical.py
@@ -487,10 +487,8 @@ class JaccardCoefficient(ConfusionMatrixMetric):
         fp = self.confusion_matrix.fp
         fn = self.confusion_matrix.fn
 
-        if (tp + fp + fn) == 0:
-            warnings.warn('Unable to compute Jaccard coefficient due to division by zero, returning -inf',
-                          NotComputableMetricWarning)
-            return float('-inf')
+        if tp == 0 and (tp + fp + fn) == 0:
+            return 1.
 
         return tp / (tp + fp + fn)
 


### PR DESCRIPTION
The `calculate` method of the `JaccardCoefficient` class has been updated in response to [issue #49](https://github.com/rundherum/pymia/issues/49). Specifically, the logic now handles cases where tp, fp, and fn are all 0, avoiding the assignment of infinity. In such cases, the Jaccard index will now correctly return 1, following the same logic used for the Dice coefficient in similar scenarios.